### PR TITLE
Ad participant data from msurvey

### DIFF
--- a/app/app.iml
+++ b/app/app.iml
@@ -4,13 +4,10 @@
     <facet type="java-gradle" name="Java-Gradle">
       <configuration>
         <option name="BUILD_FOLDER_PATH" value="$MODULE_DIR$/build" />
-        <option name="BUILDABLE" value="false" />
       </configuration>
     </facet>
   </component>
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="true">
-    <output url="file://$MODULE_DIR$/build/classes/main" />
-    <output-test url="file://$MODULE_DIR$/build/classes/test" />
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/.gradle" />
@@ -19,3 +16,4 @@
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>
+

--- a/app/app/app-app.iml
+++ b/app/app/app-app.iml
@@ -9,15 +9,9 @@
     <facet type="android" name="Android">
       <configuration>
         <option name="SELECTED_BUILD_VARIANT" value="debug" />
-        <option name="SELECTED_TEST_ARTIFACT" value="_android_test_" />
         <option name="ASSEMBLE_TASK_NAME" value="assembleDebug" />
         <option name="COMPILE_JAVA_TASK_NAME" value="compileDebugSources" />
         <option name="ASSEMBLE_TEST_TASK_NAME" value="assembleDebugAndroidTest" />
-        <option name="COMPILE_JAVA_TEST_TASK_NAME" value="compileDebugAndroidTestSources" />
-        <afterSyncTasks>
-          <task>generateDebugAndroidTestSources</task>
-          <task>generateDebugSources</task>
-        </afterSyncTasks>
         <option name="ALLOW_USER_CONFIGURATION" value="false" />
         <option name="MANIFEST_FILE_RELATIVE_PATH" value="/src/main/AndroidManifest.xml" />
         <option name="RES_FOLDER_RELATIVE_PATH" value="/src/main/res" />
@@ -150,3 +144,4 @@
     <orderEntry type="library" exported="" name="design-22.2.0" level="project" />
   </component>
 </module>
+

--- a/app/app/src/main/java/scip/app/CalendarViewActivity.java
+++ b/app/app/src/main/java/scip/app/CalendarViewActivity.java
@@ -2,9 +2,13 @@
 package scip.app;
 
 
+import android.app.AlertDialog;
+import android.content.DialogInterface;
+import android.content.Intent;
 import android.graphics.drawable.ColorDrawable;
 import android.os.Bundle;
 
+import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v7.app.ActionBarActivity;
 import android.support.v7.app.AppCompatActivity;
@@ -98,6 +102,24 @@ public class CalendarViewActivity extends ActionBarActivity {
         if(couple_id !=0) {
             Log.d("couple", "got couple");
             couple = db.getCoupleFromID(couple_id);
+            if(couple.size() > 2) {
+                AlertDialog.Builder builder = new AlertDialog.Builder(this);
+                builder.setMessage(R.string.couple_num_error_message)
+                        .setPositiveButton(R.string.couple_num_error_positive, new DialogInterface.OnClickListener() {
+                            public void onClick(DialogInterface dialog, int id) {
+                                // Do nothing and let them continue
+                            }
+                        })
+                        .setNegativeButton(R.string.couple_num_error_negative, new DialogInterface.OnClickListener() {
+                            public void onClick(DialogInterface dialog, int id) {
+                                Intent intent = new Intent(getParent(), SessionSelectionActivity.class);
+                                startActivity(intent);
+                            }
+                        });
+                // Create the AlertDialog object and return it
+                AlertDialog alert = builder.create();
+                alert.show();
+            }
         }
         else {
             couple = null;
@@ -120,8 +142,7 @@ public class CalendarViewActivity extends ActionBarActivity {
         TextView nextPeakFertilityTextView = (TextView) findViewById(R.id.peakFertilityValue);
         TextView averageCycle = (TextView) findViewById(R.id.AvgCycleValue);
 
-
-        if(couple!=null && couple.size()==2) {
+        if(couple!=null) {
             if(couple.get(0).isFemale()) {
                 female = couple.get(0);
                 male = couple.get(1);
@@ -131,7 +152,6 @@ public class CalendarViewActivity extends ActionBarActivity {
                 male = couple.get(0);
             }
         }
-
 
         if (female.getPeakFertility() != null) {
             List<Date> fertilityWindow = female.getPeakFertility().getPeakFertilityWindow();

--- a/app/app/src/main/java/scip/app/CalendarViewActivity.java
+++ b/app/app/src/main/java/scip/app/CalendarViewActivity.java
@@ -76,7 +76,10 @@ public class CalendarViewActivity extends ActionBarActivity {
         }
     }
 
-
+    private void endSession() {
+        Intent intent = new Intent(this, SessionSelectionActivity.class);
+        startActivity(intent);
+    }
 
 
     @Override
@@ -112,8 +115,7 @@ public class CalendarViewActivity extends ActionBarActivity {
                         })
                         .setNegativeButton(R.string.couple_num_error_negative, new DialogInterface.OnClickListener() {
                             public void onClick(DialogInterface dialog, int id) {
-                                Intent intent = new Intent(getParent(), SessionSelectionActivity.class);
-                                startActivity(intent);
+                                endSession();
                             }
                         });
                 // Create the AlertDialog object and return it

--- a/app/app/src/main/java/scip/app/DashboardActivity.java
+++ b/app/app/src/main/java/scip/app/DashboardActivity.java
@@ -1,6 +1,8 @@
 package scip.app;
 
 import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v7.app.ActionBarActivity;
@@ -68,6 +70,24 @@ public class DashboardActivity extends ActionBarActivity
                 int length = p.getMemscaps().size();
                 Log.d("# of MemsCaps", String.valueOf(length));
             }
+        }
+        if (couple.size() > 2) {
+            AlertDialog.Builder builder = new AlertDialog.Builder(this);
+            builder.setMessage(R.string.couple_num_error_message)
+                    .setPositiveButton(R.string.couple_num_error_positive, new DialogInterface.OnClickListener() {
+                        public void onClick(DialogInterface dialog, int id) {
+                            // Do nothing and let them continue
+                        }
+                    })
+                    .setNegativeButton(R.string.couple_num_error_negative, new DialogInterface.OnClickListener() {
+                        public void onClick(DialogInterface dialog, int id) {
+                            Intent intent = new Intent(getParent(), SessionSelectionActivity.class);
+                            startActivity(intent);
+                        }
+                    });
+            // Create the AlertDialog object and return it
+            AlertDialog alert = builder.create();
+            alert.show();
         }
 
         mNavigationDrawerFragment = (NavigationDrawerFragment)

--- a/app/app/src/main/java/scip/app/DashboardActivity.java
+++ b/app/app/src/main/java/scip/app/DashboardActivity.java
@@ -44,6 +44,10 @@ public class DashboardActivity extends ActionBarActivity
     long couple_id;
 
     FragmentTransaction fragmentTransaction = null;
+    private void endSession() {
+        Intent intent = new Intent(this, SessionSelectionActivity.class);
+        startActivity(intent);
+    }
 
 
     @Override
@@ -81,8 +85,7 @@ public class DashboardActivity extends ActionBarActivity
                     })
                     .setNegativeButton(R.string.couple_num_error_negative, new DialogInterface.OnClickListener() {
                         public void onClick(DialogInterface dialog, int id) {
-                            Intent intent = new Intent(getParent(), SessionSelectionActivity.class);
-                            startActivity(intent);
+                            endSession();
                         }
                     });
             // Create the AlertDialog object and return it

--- a/app/app/src/main/java/scip/app/DataImportActivity.java
+++ b/app/app/src/main/java/scip/app/DataImportActivity.java
@@ -46,6 +46,7 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.TimeZone;
 import java.util.ArrayList;
@@ -83,7 +84,7 @@ public class DataImportActivity extends ActionBarActivity {
         importLocalData.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                importLocalData(false);
+                importLocalData(true);
             }
         });
         importMSurveyData.setOnClickListener(new View.OnClickListener() {
@@ -151,18 +152,29 @@ public class DataImportActivity extends ActionBarActivity {
     }
 
     private void importLocalData(boolean useLocal) {
-        AsyncTask<Boolean, Void, Void> thread = new RetrieveLocalData().execute(useLocal);
+        AsyncTask<Boolean, String, Void> thread = new RetrieveLocalData().execute(useLocal);
     }
 
-    class RetrieveLocalData extends AsyncTask<Boolean, Void, Void> {
+    class RetrieveLocalData extends AsyncTask<Boolean, String, Void> {
 
         @Override
         protected Void doInBackground(Boolean... useLocal) {
             CSVImporter csvImporter = new CSVImporter(getApplicationContext());
+            HashMap resultsProcessed = null;
             if(useLocal[0])
-                csvImporter.openLocalFiles();
+                resultsProcessed = csvImporter.openLocalFiles();
             else
-                csvImporter.openExternalFiles();
+                resultsProcessed = csvImporter.openExternalFiles();
+
+            if(resultsProcessed.containsKey("participant"))
+                publishProgress(resultsProcessed.get("participant") + " participant records added");
+            if(resultsProcessed.containsKey("memscap"))
+                publishProgress(resultsProcessed.get("memscap") + " memscap records added");
+            if(resultsProcessed.containsKey("viralload"))
+                publishProgress(resultsProcessed.get("viralload") + " viral load records added");
+            if(resultsProcessed.containsKey("surveyresults"))
+                publishProgress(resultsProcessed.get("surveyresults") + " survey result records added");
+
             return null;
         }
 
@@ -180,6 +192,12 @@ public class DataImportActivity extends ActionBarActivity {
             progressBar.setVisibility(View.INVISIBLE);
             // automatically run the database backup
             AsyncTask<Void, String, String> pf = new BackupDatabase().execute();
+        }
+
+        @Override
+        protected void onProgressUpdate(String... values) {
+            super.onProgressUpdate(values);
+            statusUpdateArea.append(values[0]+"\n");
         }
     }
 

--- a/app/app/src/main/java/scip/app/DataImportActivity.java
+++ b/app/app/src/main/java/scip/app/DataImportActivity.java
@@ -331,7 +331,7 @@ public class DataImportActivity extends ActionBarActivity {
         }
 
         protected void processParticipantData(String result) {
-            publishProgress("Survey data retrieved. Parsing and storing...");
+            publishProgress("Participants retrieved. Parsing and storing...");
             JSONObject obj = null;
             try {
                 obj = new JSONObject(result);
@@ -349,7 +349,7 @@ public class DataImportActivity extends ActionBarActivity {
                 db.closeDB();
             } catch (Exception e) {
                 e.printStackTrace();
-                publishProgress("Error parsing participant data.");
+                publishProgress("Error parsing participants.");
             }
 
         }
@@ -370,8 +370,8 @@ public class DataImportActivity extends ActionBarActivity {
                     .appendQueryParameter("format", "json")
                     .build();
 
-            processSurveyResults(fetchData(survey_url));
             processParticipantData(fetchData(participant_url));
+            processSurveyResults(fetchData(survey_url));
 
             return null;
         }

--- a/app/app/src/main/java/scip/app/DataImportActivity.java
+++ b/app/app/src/main/java/scip/app/DataImportActivity.java
@@ -452,6 +452,7 @@ public class DataImportActivity extends ActionBarActivity {
     public boolean isExternalStorageWritable() {
         String state = Environment.getExternalStorageState();
         if (Environment.MEDIA_MOUNTED.equals(state)) {
+
             return true;
         }
         return false;

--- a/app/app/src/main/java/scip/app/databasehelper/CSVImporter.java
+++ b/app/app/src/main/java/scip/app/databasehelper/CSVImporter.java
@@ -171,6 +171,12 @@ public class CSVImporter {
                     processedValues.put("surveyresults", readSurveyResults(surveyResultList));
                     //f.delete();  // delete the file when you're done so the team knows it was successful
                 }
+                else if (f.getName().contains("participant") && !f.getName().contains("backup")){
+                    CSVFile csvFile = new CSVFile(f);
+                    List<String[]> participantList = csvFile.read();
+                    processedValues.put("participant", readParticipantData(participantList));
+                    //f.delete();  // delete the file when you're done so the team knows it was successful
+                }
             }
         }
         return processedValues;

--- a/app/app/src/main/java/scip/app/databasehelper/DatabaseHelper.java
+++ b/app/app/src/main/java/scip/app/databasehelper/DatabaseHelper.java
@@ -254,22 +254,21 @@ public class DatabaseHelper extends SQLiteOpenHelper{
                 return false;
             }
         }
-        else {
-            // TODO: make sure the genders match
-            Participant inDB = getParticipant(participant.getParticipantId());
-            if(inDB.isFemale() != participant.isFemale() && participant.isFemale() == true) {
-                SQLiteDatabase db = this.getWritableDatabase();
-
-                ContentValues values = new ContentValues();
-                values.put(KEY_PARTICIPANT_ID, participant.getParticipantId());
-                values.put(KEY_IS_FEMALE, intFromBoolean(participant.isFemale()));
-
-                db.update(TABLE_PARTICIPANTS, values, KEY_ID + " = ?",
-                        new String[] { String.valueOf(inDB.getId()) });
-                return true;
-            }
-
-        }
+//        else if (participant.isFemale()){
+//            Participant inDB = getParticipant(participant.getParticipantId());
+//            if(inDB.isFemale() != participant.isFemale()) {
+//                SQLiteDatabase db = this.getWritableDatabase();
+//
+//                ContentValues values = new ContentValues();
+//                values.put(KEY_PARTICIPANT_ID, participant.getParticipantId());
+//                values.put(KEY_IS_FEMALE, intFromBoolean(participant.isFemale()));
+//
+//                db.update(TABLE_PARTICIPANTS, values, KEY_ID + " = ?",
+//                        new String[] { String.valueOf(inDB.getId()) });
+//                return true;
+//            }
+//
+//        }
         Log.d("DB", "Skipping existing participant");
         return false;
 

--- a/app/app/src/main/res/values/strings.xml
+++ b/app/app/src/main/res/values/strings.xml
@@ -26,7 +26,9 @@
     <string name="undo">Undo</string>
     <string name="title_activity_viral_load">Viral Load</string>
     <string name="title_activity_participant">ParticipantActivity</string>
-
+    <string name="couple_num_error_message">There are more than 2 participants in this couple. Data may be incorrect.</string>
+    <string name="couple_num_error_positive">Continue</string>
+    <string name="couple_num_error_negative">End Session</string>
 
 
 </resources>


### PR DESCRIPTION
Add a dialog to warn against couples with more than 2 individuals, pull data from msurvey about participants, and report the number of records added to the database in data import activity. 

Since we are checking msurvey for participants, I commented out the check to make sure participants read in from memscap and viral load data files exist and that their genders match because it was slowing down the data import and we shouldn't need it. But it's still there in case they want it again (this is mostly important for @kristindew to know when she's telling them to try things. They now need a participant file on the SD card to import participant numbers or the numbers msurvey gives them need to match up)
